### PR TITLE
Two small fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -16,7 +16,7 @@ pub fn build(b: *Builder) void {
     example_exe.single_threaded = true;
     example_exe.setTarget(target);
     example_exe.setBuildMode(mode);
-    // example_exe.linkLibC();
+    example_exe.linkLibC();
     example_exe.install();
 
     const run_cmd = example_exe.run();

--- a/example.zig
+++ b/example.zig
@@ -15,8 +15,11 @@ pub fn main() !void {
     var window = try platform.createWindow(.{ .title = "Hello ZWL", .width = 1024, .height = 512, .resizeable = false, .track_damage = true, .backing_store = true, .visible = true });
     defer window.destroy();
 
-    while (true) {
-        const event = try platform.waitForEvent();
+    main_loop: while (true) {
+        const event = platform.waitForEvent() catch |err| switch(err) {
+             error.ConnectionClosed => break :main_loop,
+             else => |e| return e,
+        };
         defer platform.freeEvent(event);
 
         switch (event) {


### PR DESCRIPTION
Closing the window does a clean exit, not a error crash. Build requires libc for xcb backend.