### PR TITLE
windows.zig: Set the pointer in WM_CREATE instead of after creation

### DIFF
--- a/src/windows/user32.zig
+++ b/src/windows/user32.zig
@@ -35,6 +35,21 @@ pub const MSG = extern struct {
     lPrivate: DWORD,
 };
 
+pub const CREATESTRUCTW = extern struct {
+    lpCreateParams: LPVOID,
+    hInstance: HINSTANCE,
+    hMenu: ?HMENU,
+    hwndParent: ?HWND,
+    cy: c_int,
+    cx: c_int,
+    y: c_int,
+    x: c_int,
+    style: LONG,
+    lpszName: LPCWSTR,
+    lpszClass: LPCWSTR,
+    dwExStyle: DWORD,
+};
+
 pub const WM = extern enum(u32) {
     pub const WININICHANGE = @This().SETTINGCHANGE;
 


### PR DESCRIPTION
When creating the window, I would often get the WM_SIZE message before
CreateWindowExW returned. This would result in ZWL spuriously thinking
it recieved the WM_SIZE command in an unknown window. Since WM_CREATE
is the first message you can get it makes sense to do this sort of
setup in there instead of after CreateWindowExW returns