### PR TITLE
Xlib does not use the title passed from zwl.WindowOptions

### DIFF
--- a/src/xlib.zig
+++ b/src/xlib.zig
@@ -294,7 +294,7 @@ pub fn Platform(comptime Parent: anytype) type {
                 }
 
                 _ = c.XMapWindow(parent.display, self.window);
-                _ = c.XStoreName(parent.display, self.window, "VERY SIMPLE APPLICATION");
+                _ = c.XStoreName(parent.display, self.window, title);
             }
 
             fn initGL(self: *Window, parent: *Self, options: zwl.WindowOptions) !void {
@@ -412,7 +412,7 @@ pub fn Platform(comptime Parent: anytype) type {
                 }
 
                 _ = c.XMapWindow(parent.display, self.window);
-                _ = c.XStoreName(parent.display, self.window, "VERY SIMPLE APPLICATION");
+                _ = c.XStoreName(parent.display, self.window, title);
 
                 const version = options.backend.opengl;
 

--- a/src/xlib.zig
+++ b/src/xlib.zig
@@ -288,6 +288,11 @@ pub fn Platform(comptime Parent: anytype) type {
                     &swa,
                 );
 
+                var title: [:0]const u8 = "VERY SIMPLE APPLICATION";
+                if (options.title != null) {
+                    title = try std.cstr.addNullByte(std.heap.c_allocator, options.title.?);
+                }
+
                 _ = c.XMapWindow(parent.display, self.window);
                 _ = c.XStoreName(parent.display, self.window, "VERY SIMPLE APPLICATION");
             }
@@ -400,6 +405,11 @@ pub fn Platform(comptime Parent: anytype) type {
                 );
                 if (self.window == 0)
                     return error.CouldNotCreateWindow;
+
+                var title: [:0]const u8 = "VERY SIMPLE APPLICATION";
+                if (options.title != null) {
+                    title = try std.cstr.addNullByte(std.heap.c_allocator, options.title.?);
+                }
 
                 _ = c.XMapWindow(parent.display, self.window);
                 _ = c.XStoreName(parent.display, self.window, "VERY SIMPLE APPLICATION");


### PR DESCRIPTION
this pr adds the ability to set the title for an Xlib window,
it uses the c_allocator to create a c string.

Im a bit new to git pull requests and this lib in general.
Would the lib need to deallocate the var title created by c_allocator?
and if so where?